### PR TITLE
Fix attribute_conversion in build.schema.json

### DIFF
--- a/src/configuration/build.schema.json
+++ b/src/configuration/build.schema.json
@@ -991,22 +991,25 @@
             }
         },
         "attribute_conversion": {
-            "condition": {
-                "$ref": "#/definitions/condition"
-            },
-            "from": {
-                "$ref": "#/definitions/attribute"
-            },
-            "to": {
-                "$ref": "#/definitions/attribute"
-            },
-            "multiplier": {
-                "type": "number",
-                "default": 1.0
-            },
-            "addend": {
-                "type": "number",
-                "default": 0.0
+            "type": "object",
+            "properties": {
+                "condition": {
+                    "$ref": "#/definitions/condition"
+                },
+                "from": {
+                    "$ref": "#/definitions/attribute"
+                },
+                "to": {
+                    "$ref": "#/definitions/attribute"
+                },
+                "multiplier": {
+                    "type": "number",
+                    "default": 1.0
+                },
+                "addend": {
+                    "type": "number",
+                    "default": 0.0
+                }
             }
         },
         "counter_modifier": {


### PR DESCRIPTION
Previously the schema did not display attribute_conversions, this fixes this.