### PR TITLE
Add more combat termination conditions

### DIFF
--- a/src/combat_loop.cpp
+++ b/src/combat_loop.cpp
@@ -215,6 +215,44 @@ bool continue_combat_loop(registry_t& registry, const configuration::encounter_t
                 return false;
             }
         } else if (termination_condition.type ==
+                   configuration::termination_condition_t::type_t::NO_ACTIVE_SKILLS) {
+            bool no_active_skills = true;
+            for (auto entity : registry.view<component::is_actor>()) {
+                if (!termination_condition.actor.empty() &&
+                    utils::get_entity_name(entity, registry) != termination_condition.actor) {
+                    continue;
+                }
+                if (registry.any_of<component::skills_ticks_tracker_component,
+                                    component::skills_actions_component,
+                                    component::finished_skills_actions_component,
+                                    component::destroy_skills_ticks_tracker_component>(entity)) {
+                    no_active_skills = false;
+                    break;
+                }
+            }
+            if (no_active_skills) {
+                return false;
+            }
+        } else if (termination_condition.type ==
+                   configuration::termination_condition_t::type_t::NO_MORE_ROTATION) {
+            bool no_more_rotation = true;
+            for (auto entity : registry.view<component::is_actor>()) {
+                if (!termination_condition.actor.empty() &&
+                    utils::get_entity_name(entity, registry) != termination_condition.actor) {
+                    continue;
+                }
+                if (!registry.any_of<component::rotation_component>(entity)) {
+                    continue;
+                }
+                if (!registry.any_of<component::no_more_rotation>(entity)) {
+                    no_more_rotation = false;
+                    break;
+                }
+            }
+            if (no_more_rotation) {
+                return false;
+            }
+        } else if (termination_condition.type ==
                    configuration::termination_condition_t::type_t::DAMAGE) {
             bool someone_took_required_damage = false;
             for (auto&& [entity, static_attributes, combat_stats] :

--- a/src/configuration/encounter.hpp
+++ b/src/configuration/encounter.hpp
@@ -26,6 +26,8 @@ struct termination_condition_t {
         TIME,
         ROTATION,
         DAMAGE,
+        NO_ACTIVE_SKILLS,
+        NO_MORE_ROTATION,
     };
     type_t type = type_t::INVALID;
     tick_t time = 0;
@@ -68,8 +70,10 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(actor_t,
 NLOHMANN_JSON_SERIALIZE_ENUM(termination_condition_t::type_t,
                              {{termination_condition_t::type_t::INVALID, "invalid"},
                               {termination_condition_t::type_t::TIME, "TIME"},
-                              {termination_condition_t::type_t::ROTATION, "ROTATION"},
-                              {termination_condition_t::type_t::DAMAGE, "DAMAGE"}})
+                             {termination_condition_t::type_t::ROTATION, "ROTATION"},
+                             {termination_condition_t::type_t::DAMAGE, "DAMAGE"},
+                             {termination_condition_t::type_t::NO_ACTIVE_SKILLS, "NO_ACTIVE_SKILLS"},
+                             {termination_condition_t::type_t::NO_MORE_ROTATION, "NO_MORE_ROTATION"}})
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(termination_condition_t, type, time, actor, damage)
 NLOHMANN_JSON_SERIALIZE_ENUM(weapon_strength_mode_t,
                              {{weapon_strength_mode_t::MEAN, "MEAN"},

--- a/src/configuration/encounter.schema.json
+++ b/src/configuration/encounter.schema.json
@@ -1187,7 +1187,9 @@
                     "enum": [
                         "TIME",
                         "ROTATION",
-                        "DAMAGE"
+                        "DAMAGE",
+                        "NO_ACTIVE_SKILLS",
+                        "NO_MORE_ROTATION"
                     ]
                 },
                 "time": {
@@ -1212,6 +1214,9 @@
                 },
                 {
                     "required": ["type", "actor", "damage"]
+                },
+                {
+                    "required": ["type"]
                 }
             ]
         }


### PR DESCRIPTION
## Summary
- add `NO_ACTIVE_SKILLS` and `NO_MORE_ROTATION` termination types
- implement logic to exit combat when these conditions are met
- extend encounter schema with new termination types

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_683fb2686de8832aa2fa032d14850e57