### PR TITLE
Remove stray boon duration line

### DIFF
--- a/src/utils/effect_utils.hpp
+++ b/src/utils/effect_utils.hpp
@@ -228,7 +228,6 @@ namespace gw2combat::utils {
         case actor::effect_t::STABILITY:
             return calculate_boon_duration(source_relative_attributes.get(
                 target_entity, actor::attribute_t::STABILITY_DURATION_MULTIPLIER));
-            return calculate_boon_duration();
 
         case actor::effect_t::BLINDED:
         case actor::effect_t::CHILLED:


### PR DESCRIPTION
## Summary
- remove a stray `calculate_boon_duration` call in the effect switch

## Testing
- `make -j 4` *(fails: missing dependencies?)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1fc0c50832ab803d08d37367ab1